### PR TITLE
docs: overhaul README with project branding and details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,59 @@
-# Create T3 App
+<div align="center">
+   <img align="center" width="128px" src="public/logo.png" />
+	<h1 align="center"><b>The Presentation Foundation</b></h1>
+	<p align="center">
+		Online Presentation Data Management Cloud Platform for easy access and disribution of your presentations. 
+    <br />
+    <a href="https://pr.djl.foundation"><strong>pr.djl.foundation »</strong></a>
+  </p>
+</div>
 
-This is a [T3 Stack](https://create.t3.gg/) project bootstrapped with `create-t3-app`.
+<br/>
 
-## What's next? How do I make an app with this?
+![Alt](https://repobeats.axiom.co/api/embed/4dd2b79bf0398bf65b3ea61807418169d40fac67.svg "Repobeats analytics image")
 
-We try to keep this project as simple as possible, so you can start with just the scaffolding we set up for you, and add additional things later when they become necessary.
+<div align="center">
+  <a href="https://gitbutler.com/">
+    <img src="https://img.shields.io/badge/GitButler-%23B9F4F2?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB3aWR0aD0iMzkiIGhlaWdodD0iMjgiIHZpZXdCb3g9IjAgMCAzOSAyOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTI1LjIxNDUgMTIuMTk5N0wyLjg3MTA3IDEuMzg5MTJDMS41NDI5NSAwLjc0NjUzMiAwIDEuNzE0MDYgMCAzLjE4OTQ3VjI0LjgxMDVDMCAyNi4yODU5IDEuNTQyOTUgMjcuMjUzNSAyLjg3MTA3IDI2LjYxMDlMMjUuMjE0NSAxNS44MDAzQzI2LjcxOTcgMTUuMDcyMSAyNi43MTk3IDEyLjkyNzkgMjUuMjE0NSAxMi4xOTk3WiIgZmlsbD0iYmxhY2siLz4KPHBhdGggZD0iTTEzLjc4NTUgMTIuMTk5N0wzNi4xMjg5IDEuMzg5MTJDMzcuNDU3MSAwLjc0NjUzMiAzOSAxLjcxNFA2IDM5IDMuMTg5NDdWMjQuODEwNUMzOSAyNi4yODU5IDM3LjQ1NzEgMjcuMjUzNSAzNi4xMjg5IDI2LjYxMDlMMTMuNzg1NSAxNS44MDAzQzEyLjI4MDMgMTUuMDcyMSAxMi4yODAzIDEyLjkyNzkgMTMuNzg1NSAxMi4xOTk3WiIgZmlsbD0idXJsKCNwYWludDBfcmFkaWFsXzMxMF8xMjkpIi8%2BCjxkZWZzPgo8cmFkaWFsR3JhZGllbnQgaWQ9InBhaW50MF9yYWRpYWxfMzEwXzEyOSIgY3g9IjAiIGN5PSIwIiByPSIxIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgZ3JhZGllbnRUcmFuc2Zvcm09InRyYW5zbGF0ZSgxNi41NzAxIDE0KSBzY2FsZSgxOS44NjQxIDE5LjgzODMpIj4KPHN0b3Agb2Zmc2V0PSIwLjMwMTA1NiIgc3RvcC1vcGFjaXR5PSIwIi8%2BCjxzdG9wIG9mZnNldD0iMSIvPgo8L3JhZGlhbEdyYWRpZW50Pgo8L2RlZnM%2BCjwvc3ZnPgo%3D" alt="GitButler" />
+  </a>
+  <br />
+  <a href="https://github.com/djl-foundation/presentation-foundation/issues">
+    <img src="https://img.shields.io/github/issues/djl-foundation/presentation-foundation?style=flat-square" alt="GitHub issues" />
+  </a>
+  <a href="https://github.com/djl-foundation/presentation-foundation/pulls">
+    <img src="https://img.shields.io/github/issues-pr/djl-foundation/presentation-foundation?style=flat-square" alt="GitHub pull requests" />
+  </a>
+  <a href="https://github.com/djl-foundation/presentation-foundation/blob/main/LICENSE">
+    <img src="https://img.shields.io/github/license/djl-foundation/presentation-foundation?style=flat-square" alt="GitHub license" />
+  </a>
+  <br />
+  <a href="https://github.com/djl-foundation/presentation-foundation/stargazers">
+    <img src="https://img.shields.io/github/stars/djl-foundation/presentation-foundation?style=social" alt="GitHub stars" />
+  </a>
+  <a href="https://github.com/djl-foundation/presentation-foundation/graphs/contributors">
+    <img src="https://img.shields.io/github/contributors/djl-foundation/presentation-foundation?style=flat-square" alt="GitHub contributors" />
+  </a>
+  <a href="https://github.com/djl-foundation/presentation-foundation/commits">
+    <img src="https://img.shields.io/github/last-commit/djl-foundation/presentation-foundation?style=flat-square" alt="GitHub last commit" />
+  </a>
+</div>
 
-If you are not familiar with the different technologies used in this project, please refer to the respective docs. If you still are in the wind, please join our [Discord](https://t3.gg/discord) and ask for help.
+## About the Presentation Foundation
 
-- [Next.js](https://nextjs.org)
-- [NextAuth.js](https://next-auth.js.org)
-- [Prisma](https://prisma.io)
-- [Drizzle](https://orm.drizzle.team)
-- [Tailwind CSS](https://tailwindcss.com)
-- [tRPC](https://trpc.io)
+The Presentation Foundation is an initiative by the DJL Foundation, a nonprofit association based in Germany. Our mission is to make the management and distribution of presentation materials accessible, transparent, and community-driven. We believe that knowledge and educational resources should be easy to share, remix, and build upon—without unnecessary barriers or proprietary lock-in.
 
-## Learn More
+### Our Goals
 
-To learn more about the [T3 Stack](https://create.t3.gg/), take a look at the following resources:
+- **Open Access:** Enable anyone to host, access, and distribute presentations freely, supporting both private and public sharing.
+- **Simplicity:** Provide a platform that is intuitive and easy to use, lowering the technical barrier for educators, students, and organizations.
+- **Transparency:** Operate as an open-source project, inviting contributions and feedback from the community. All code is public, and development is guided by the needs of our users.
+- **Privacy and Control:** Respect user privacy and give users control over their data and content. We do not monetize user data or restrict access through paywalls.
+- **Community Collaboration:** Foster a collaborative environment where improvements, ideas, and new features are shaped by contributors from around the world.
 
-- [Documentation](https://create.t3.gg/)
-- [Learn the T3 Stack](https://create.t3.gg/en/faq#what-learning-resources-are-currently-available) — Check out these awesome tutorials
+### Why Open Source?
 
-You can check out the [create-t3-app GitHub repository](https://github.com/t3-oss/create-t3-app) — your feedback and contributions are welcome!
+We believe that open-source software empowers individuals and organizations to take ownership of their tools. By making our code and processes public, we encourage learning, transparency, and trust. Contributions are welcome from anyone who shares our vision for accessible, community-driven presentation management.
 
-## How do I deploy this?
+---
 
-Follow our deployment guides for [Vercel](https://create.t3.gg/en/deployment/vercel), [Netlify](https://create.t3.gg/en/deployment/netlify) and [Docker](https://create.t3.gg/en/deployment/docker) for more information.
+For more information about the DJL Foundation and our other projects, visit [djl.foundation](https://djl.foundation) or [parking.djl.foundation](https://parking.djl.foundation).


### PR DESCRIPTION
- Replaced the default T3 app README with a branded introduction for the Presentation Foundation project  
- Added project description, logo, and links to the live site  
- Included badges for build status, issues, pull requests, license, stars, contributors, and last commit  
- Provided background about the foundation and clarified the project's mission to enhance clarity and professionalism